### PR TITLE
Select Multiple Categories for Questions Only

### DIFF
--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -32,10 +32,7 @@ $('document').ready(function() {
 
 		if (
 			config['question-and-answer'].forceQuestions === 'on' ||
-			(
-				config['question-and-answer'].makeDefault === 'on' &&
-				(config['question-and-answer'].defaultCid === "0" || parseInt(config['question-and-answer'].defaultCid, 10) === parseInt(data.composerData.cid, 10))
-			)
+			(config['question-and-answer']['defaultCid_' + data.composerData.cid] === 'on')
 		) {
 			$('.composer-submit').attr('data-action', 'post').html('<i class="fa fa-fw fa-question-circle"></i> Ask as Question</a>');
 			$(window).off('action:composer.topics.post').one('action:composer.topics.post', function(ev, data) {

--- a/static/templates/admin/plugins/question-and-answer.tpl
+++ b/static/templates/admin/plugins/question-and-answer.tpl
@@ -5,28 +5,24 @@
 			<div class="checkbox">
 				<label>
 					<input type="checkbox" name="forceQuestions">
-					Only allow questions to be asked (disables regular topic behaviour)
+					Only allow questions to be asked for all categories (disables regular topic behaviour)
 				</label>
 				<p class="help-block">
 					This option supercedes the one below
 				</p>
 			</div>
 			<hr />
+			<label>
+				Only allow questions to be asked for the following categories (disables regular topic behaviour)
+			</label>
+			<!-- BEGIN categories -->
 			<div class="checkbox">
 				<label>
-					<input type="checkbox" name="makeDefault">
-					Change the default behaviour for new topics to be a Q&amp;A topic
+					<input type="checkbox" name="defaultCid_{../cid}">
+					{../name}
 				</label>
 			</div>
-			<div class="form-group">
-				<label for="defaultCid">Limit this to a single category</label>
-				<select class="form-control" id="defaultCid" name="defaultCid">
-					<option value="0">N/A</option>
-					<!-- BEGIN categories -->
-					<option value="{../cid}">{../name}</option>
-					<!-- END categories -->
-				</select>
-			</div>
+			<!-- END categories -->
 		</div>
 	</div>
 </form>


### PR DESCRIPTION
* Allow users to select multiple categories that only allow questions
* Change the wording in the plugin settings to make the effects more
clear

![screen shot 2016-09-14 at 5 16 03 pm](https://cloud.githubusercontent.com/assets/2993523/18534371/1713119a-7a9f-11e6-9fb6-edc335afa9a6.png)
