### PR TITLE
Updated plugin to use filter:topic.create

### DIFF
--- a/library.js
+++ b/library.js
@@ -29,18 +29,19 @@ plugin.init = function (params, callback) {
 
 	handleSocketIO();
 
-	callback();
-};
-
-plugin.appendConfig = function (config, callback) {
 	meta.settings.get('question-and-answer', function (err, settings) {
 		if (err) {
 			return callback(err);
 		}
 
-		config['question-and-answer'] = settings;
-		callback(null, config);
+		plugin._settings = settings;
+		callback();
 	});
+};
+
+plugin.appendConfig = function (config, callback) {
+	config['question-and-answer'] = plugin._settings;
+	setImmediate(callback, null, config);
 };
 
 plugin.addNavigation = function (menu, callback) {
@@ -147,6 +148,24 @@ plugin.getConditions = function (conditions, callback) {
 	});
 
 	callback(false, conditions);
+};
+
+plugin.onTopicCreate = function (payload, callback) {
+	if (payload.data.hasOwnProperty('isQuestion')) {
+		payload.topic.isQuestion = !!payload.data.isQuestion ? 1 : 0;
+	}
+
+	if (payload.data.hasOwnProperty('isSolved')) {
+		payload.topic.isSolved = !!payload.data.isSolved ? 1 : 0;
+	}
+
+	// Overrides from ACP config
+	if (plugin._settings.forceQuestions === 'on' || plugin._settings['defaultCid_' + payload.topic.cid] === 'on') {
+		payload.topic.isQuestion = 1;
+		payload.topic.isSolved = 0;
+	}
+
+	setImmediate(callback, null, payload);
 };
 
 function renderAdmin(req, res, next) {

--- a/library.js
+++ b/library.js
@@ -152,11 +152,11 @@ plugin.getConditions = function (conditions, callback) {
 
 plugin.onTopicCreate = function (payload, callback) {
 	if (payload.data.hasOwnProperty('isQuestion')) {
-		payload.topic.isQuestion = !!payload.data.isQuestion ? 1 : 0;
+		payload.topic.isQuestion = parseInt(payload.data.isQuestion, 10);
 	}
 
 	if (payload.data.hasOwnProperty('isSolved')) {
-		payload.topic.isSolved = !!payload.data.isSolved ? 1 : 0;
+		payload.topic.isSolved = parseInt(payload.data.isSolved, 10);
 	}
 
 	// Overrides from ACP config

--- a/plugin.json
+++ b/plugin.json
@@ -28,6 +28,9 @@
 		},
 		{
 			"hook": "filter:rewards.conditions", "method": "getConditions"
+		},
+		{
+			"hook": "filter:topic.create", "method": "onTopicCreate"
 		}
 	],
 	"staticDirs": {

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -16,31 +16,21 @@ $('document').ready(function () {
 	$(window).on('action:posts.loaded', markPostAsSolved);
 
 	$(window).on('action:composer.loaded', function (ev, data) {
-		var isReply = data.hasOwnProperty('composerData') && !data.composerData.isMain;
-		if (isReply) {
+		// Return early if it is a reply and not a new topic
+		if (data.hasOwnProperty('composerData') && !data.composerData.isMain) {
 			return;
 		}
 
 		var item = $('<button type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown"><span class="caret"></span></button><ul class="dropdown-menu pull-right" role="menu"><li><a href="#" data-switch-action="post"><i class="fa fa-fw fa-question-circle"></i> Ask as Question</a></li></ul>');
-		var actionBar = $('#cmp-uuid-' + data.post_uuid + ' .action-bar');
+		var actionBar = $('.composer[data-uuid="' + data.post_uuid + '"] .action-bar');
 
 		item.on('click', 'li', function () {
-			$(window).off('action:composer.topics.post').one('action:composer.topics.post', function (ev, data) {
-				callToggleQuestion(data.data.tid, false);
+			$(window).one('action:composer.submit', function (e, data) {
+				data.composerData.isQuestion = true;
 			});
 		});
 
-		if (
-			config['question-and-answer'].forceQuestions === 'on' ||
-			(config['question-and-answer']['defaultCid_' + data.composerData.cid] === 'on')
-		) {
-			$('.composer-submit').attr('data-action', 'post').html('<i class="fa fa-fw fa-question-circle"></i> Ask as Question</a>');
-			$(window).off('action:composer.topics.post').one('action:composer.topics.post', function (ev, data) {
-				callToggleQuestion(data.data.tid, false);
-			});
-		} else {
-			actionBar.append(item);
-		}
+		actionBar.append(item);
 	});
 
 	function addHandlers() {


### PR DESCRIPTION
Initially this plugin used a client-side toggle that would wait
until after a topic was posted, and then make a socket call to
toggle the question status. Write API couldn't hook into this,
so a server-side solution using filter:topic.create is required.

Also, I fixed issues with the "Ask a Question" label not showing
up in the composer dropdown.

Lastly, settings are now saved in a local variable called
plugin._settings. Side effect of this change is that a reload is
now required after changing ACP settings. Prior to this, the
settings were retrieved every time the page was reloaded.