### PR TITLE
feat: add option to only allow administrators and moderators to mark as solved

### DIFF
--- a/static/languages/en-GB/qanda.json
+++ b/static/languages/en-GB/qanda.json
@@ -19,5 +19,6 @@
     "admin.form.label.only_allow_all": "Only allow questions to be asked for all categories (disables regular topic behaviour)",
     "admin.form.label.only_allow_following": "Only allow questions to be asked for the following categories (disables regular topic behaviour)",
     "admin.form.tips": "This option supercedes the one below",
-    "admin.form.label.toggle_lock": "Automatically close solved topics"
+    "admin.form.label.toggle_lock": "Automatically close solved topics",
+    "admin.form.label.only_allow_admins": "Only allow questions to be set as solved by moderators and administrators"
 }

--- a/static/languages/en-US/qanda.json
+++ b/static/languages/en-US/qanda.json
@@ -18,5 +18,6 @@
     "admin.form.label.only_allow_all": "Only allow questions to be asked for all categories (disables regular topic behaviour)",
     "admin.form.label.only_allow_following": "Only allow questions to be asked for the following categories (disables regular topic behaviour)",
     "admin.form.tips": "This option supercedes the one below",
-    "admin.form.label.toggle_lock": "Automatically close solved topics"
+    "admin.form.label.toggle_lock": "Automatically close solved topics",
+    "admin.form.label.only_allow_admins": "Only allow questions to be set as solved by moderators and administrators"
 }

--- a/static/templates/admin/plugins/question-and-answer.tpl
+++ b/static/templates/admin/plugins/question-and-answer.tpl
@@ -13,6 +13,13 @@
 
 			<div class="checkbox">
 				<label>
+					<input type="checkbox" name="onlyAdmins">
+					[[qanda:admin.form.label.only_allow_admins]]
+				</label>
+			</div>
+
+			<div class="checkbox">
+				<label>
 					<input type="checkbox" name="forceQuestions">
 					[[qanda:admin.form.label.only_allow_all]]
 				</label>


### PR DESCRIPTION
resolves #88

Adds a setting that only allows moderators and administrators to mark questions as solved.

Community forum reference: https://community.nodebb.org/topic/16617/question-and-answer-plugin-permissions